### PR TITLE
ci(bors): ステータス確認先をci/circleciからci/circleci: testへ変更した

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,1 +1,1 @@
-status = ["ci/circleci"]
+status = ["ci/circleci: test"]


### PR DESCRIPTION
Caused by https://circleci.com/docs/2.0/workflows-waiting-status/